### PR TITLE
Endorse button and updated Ajax calls

### DIFF
--- a/ender/.themes/classic/source/_includes/asides/coderwall.html
+++ b/ender/.themes/classic/source/_includes/asides/coderwall.html
@@ -26,7 +26,8 @@
         showBadges: function(options){
           $.ajax({
               url: 'http://coderwall.com/' + options.user + '.json?callback=?'
-            , type: 'jsonp'
+            , dataType: 'jsonp'
+            , type: 'GET'
             , error: function (err) { $(options.target + ' li.loading').addClass('error').text("Error loading feed"); }
             , success: function(res) {
                 render(options, res.data.badges);
@@ -36,7 +37,7 @@
       };
     })();
 
-    $.domReady(function(){
+    $(document).ready(function(){
       if (!window.jXHR){
         var jxhr = document.createElement('script');
         jxhr.type = 'text/javascript';

--- a/jQuery/source/_includes/asides/coderwall.html
+++ b/jQuery/source/_includes/asides/coderwall.html
@@ -53,5 +53,11 @@
       box-shadow: none !important;
     }
   </style>
+
+  <div>
+    <a href="http://coderwall.com/{{site.coderwall_user}}"><img
+       alt="Endorse {{site.coderwall_user}} on Coderwall"
+       src="http://api.coderwall.com/{{site.coderwall_user}}/endorsecount.png" /></a>
+  </div>
 </section>
 {% endif %}

--- a/jQuery/source/_includes/asides/coderwall.html
+++ b/jQuery/source/_includes/asides/coderwall.html
@@ -54,10 +54,12 @@
     }
   </style>
 
+  {% if site.coderwall_endorse %}
   <div>
     <a href="http://coderwall.com/{{site.coderwall_user}}"><img
        alt="Endorse {{site.coderwall_user}} on Coderwall"
        src="http://api.coderwall.com/{{site.coderwall_user}}/endorsecount.png" /></a>
   </div>
+  {% endif %}
 </section>
 {% endif %}


### PR DESCRIPTION
I was having problems with a fresh install of Octopress today and your plugin. Using $(document).ready and adding the dataType attribute to the ajax options fixed this. I've forked kaineer repo because he added the option of including an endorse button. Please can you merge this. Cheers, Ewan
